### PR TITLE
Arreglando el formato BGR a RGB para PIL y cv2 para las imagenes a color

### DIFF
--- a/ProyectoMetaheuristicos/proyectoGUI.py
+++ b/ProyectoMetaheuristicos/proyectoGUI.py
@@ -101,15 +101,20 @@ class ImageApp:
         window.title("Resultados de filtrado")
 
         # Convertir las imágenes de OpenCV a PIL para poder mostrarlas en Tkinter
-        noisy_image_pil = Image.fromarray(noisy_image)
-        filtered_image_pil = Image.fromarray(filtered_image)
+        noisy_image_cv = cv2.cvtColor(noisy_image, cv2.COLOR_BGR2RGB)
+        filtered_image_cv = cv2.cvtColor(filtered_image, cv2.COLOR_BGR2RGB)
+
+        # Convertir las imagenes de OpenCV a PIL para poder mostrarlas en Tkinter
+        noisy_image_pil = Image.fromarray(noisy_image_cv)
+        filtered_image_pil = Image.fromarray(filtered_image_cv)
 
         # Verificar si sharpened_image es un objeto Image o un array
         if isinstance(sharpened_image, Image.Image):
             sharpened_image_pil = sharpened_image  # Ya es una imagen PIL
         else:
-            # Si es un array, conviértelo a PIL
-            sharpened_image_pil = Image.fromarray(sharpened_image)
+            # Si es un array, convertir a PIL
+            sharpened_image_cv = cv2.cvtColor(sharpened_image, cv2.COLOR_BGR2RGB)
+            sharpened_image_pil = Image.fromarray(sharpened_image_cv)
 
         # Convertir PIL a ImageTk
         self.noisy_image_tk = ImageTk.PhotoImage(noisy_image_pil)

--- a/ProyectoMetaheuristicos/taboo_img.py
+++ b/ProyectoMetaheuristicos/taboo_img.py
@@ -161,7 +161,10 @@ def sharpen_image(image_pil, update_progress, sharpen_iters):
     # Aplicación de los filtros a la imagen
     final_image = apply_filters(image, best_blur_mask, best_sharp_mask)
 
-    # Convertir la imagen final a PIL antes de devolver
-    final_image_pil = Image.fromarray(final_image)
+    # cambio BGR A RGB 
+    final_image_cv = cv2.cvtColor(final_image, cv2.COLOR_BGR2RGB)
+
+    # Regresar el formato a PIL
+    final_image_pil = Image.fromarray(final_image_cv)
 
     return final_image_pil, best_blur_mask, best_sharp_mask, best_snr


### PR DESCRIPTION
Se cambió en los codigos de afilado y de la interfaz la forma en que manipula los valores BGR y RGB ya que PIL y CV no eran compatibles en ese aspecto.